### PR TITLE
メモリ使用量周りの変更

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -48,7 +48,7 @@ global.on("event", async (ev) => {
   events.value = events.value.filter((event, index, array) => {
     return index === 0 || event.id !== array[index - 1].id
   })
-
+  events.value = events.value.slice(0, 200);
   if (!firstFetching && autoSpeech.value) {
     speakNote(ev);
   }

--- a/src/App.vue
+++ b/src/App.vue
@@ -97,8 +97,14 @@ async function collectProfiles() {
     if (ev.kind === 0) {
       const content = JSON.parse(ev.content)
       if (!profiles.value.has(ev.pubkey) || profiles.value.get(ev.pubkey)?.created_at < ev.created_at) {
-        content.created_at = ev.created_at
-        profiles.value.set(ev.pubkey, content)
+        const press = {
+          picture: content.picture,
+          display_name: content.display_name,
+          name: content.name,
+          created_at: ev.created_at,
+        }
+        // content.created_at = ev.created_at
+        profiles.value.set(ev.pubkey, press)
       }
     } else if (ev.kind === 3) {
       if (false && ev.content) { // プロフィール情報を取得するリレーを各人のものから拾おうとしたが、非常に多くなりすぎるのでやめた


### PR DESCRIPTION
以下の内容を対応しました。

- ユーザープロフィールのキャッシュ容量を削減
  - LocalStorageの容量は一般的に5MBのため、不要な情報を削減
  - エラー対応はしていないため、ユーザー数の急激な増加に備える
- TLの最大件数を200件に変更
  - メモリ使用量の削減
  - スクロール量を減らせる
  - 必要に応じて、50件等に変更してください（rabbitはもっと少ない）