### PR TITLE
Remove bostr.nokotaro.work

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -7,7 +7,6 @@ export const feedRelays = ["wss://relay-jp.nostr.wirednet.jp/"];
 
 export const profileRelays = [
   "wss://bostr.nokotaro.com/",
-  "wss://bostr.nokotaro.work/",
   "wss://ipv6.nostr.wirednet.jp/",
   "wss://nos.lol/",
   "wss://nostr-pub.wellorder.net/",


### PR DESCRIPTION
bostr.nokotaro.work は bostr.nokotaro.com と同じBostrリレーを向くようにしたので削除