### PR TITLE
Fix emoji profile random selection

### DIFF
--- a/src/hooks/useEmojiProfiles.ts
+++ b/src/hooks/useEmojiProfiles.ts
@@ -25,11 +25,11 @@ export function getRandomProfile(pubkey: string, sushiMode: Boolean = false, mah
   if (sushiMode && mahjongMode) {
     randomNumber = pubkeyNumber % (sushiDataLength + mahjongDataLength);
   } else if (sushiMode) {
-    randomNumber = pubkeyNumber % (sushiDataLength);
-    const c = characters[randomNumber];
+    randomNumber = pubkeyNumber % sushiDataLength;
   } else if (mahjongMode) {
-    randomNumber = sushiDataLength + pubkeyNumber % (mahjongDataLength);
-    const c = characters[randomNumber];
+    randomNumber = sushiDataLength + (pubkeyNumber % mahjongDataLength);
+  } else {
+    randomNumber = pubkeyNumber % characters.length;
   }
   const c = characters[randomNumber];
   const p: Profile = {


### PR DESCRIPTION
## Summary
- Correct default random profile selection to use full emoji list
- Remove unused variables in sushi/mahjong mode branches

## Testing
- `npx vitest run`
- `npx vitest run tests/tmpRandom.test.ts` *(verifies varied profiles for different pubkeys)*


------
https://chatgpt.com/codex/tasks/task_e_68a7d3f9aa648331846c656e1348388e